### PR TITLE
Fix for newer kernels

### DIFF
--- a/aziokbd.c
+++ b/aziokbd.c
@@ -402,7 +402,7 @@ static int usb_kbd_probe(struct usb_interface *iface,
 		return -ENODEV;
 
 	pipe = usb_rcvintpipe(dev, endpoint->bEndpointAddress);
-	maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
+	maxp = usb_maxpacket(dev, pipe);
 	kbd = kzalloc(sizeof(struct usb_kbd), GFP_KERNEL);
 	input_dev = input_allocate_device();
 	if (!kbd || !input_dev)
@@ -415,7 +415,7 @@ static int usb_kbd_probe(struct usb_interface *iface,
 	kbd->dev = input_dev;
 
 	if (dev->manufacturer)
-		strlcpy(kbd->name, dev->manufacturer, sizeof(kbd->name));
+		strscpy(kbd->name, dev->manufacturer, sizeof(kbd->name));
 
 	if (dev->product) {
 		if (dev->manufacturer)


### PR DESCRIPTION
- remove third argument in usb_maxpacket()
- replace strlcpy with strscpy

https://patchwork.kernel.org/project/linux-usb/patch/20220304105420.1059585-1-mailhol.vincent@wanadoo.fr/

https://forums.developer.nvidia.com/t/6-8-kernel-breaking-changes-on-mellanox-ofed-5-8/309436